### PR TITLE
Refresh homepage positioning copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Allan Yeung builds practical systems at the intersection of product, data, cloud, and automation.">
-  <title>Allan Yeung | Product, Data, Cloud, Automation</title>
+  <meta name="description" content="Allan Yeung is an operator, Principal Product Manager, and entrepreneur focused on customer-led products, developer experience, finance, and team execution.">
+  <title>Allan Yeung | Operator, Product Manager, Entrepreneur</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -14,20 +14,23 @@
   <header class="site-header">
     <a class="brand" href="/" aria-label="Allan Yeung home">AY</a>
     <nav class="site-nav" aria-label="Primary navigation">
-      <a href="#work">Work</a>
-      <a href="#projects">Projects</a>
+      <a href="#how">How I Work</a>
+      <a href="#life">Work, Learning, and Life</a>
       <a href="#connect">Connect</a>
     </nav>
   </header>
 
   <main>
     <section class="hero" aria-labelledby="intro-title">
-      <div class="eyebrow">Product-minded technologist</div>
-      <h1 id="intro-title">I turn messy operating questions into useful systems.</h1>
+      <div class="eyebrow">Operator, Principal Product Manager, Entrepreneur</div>
+      <h1 id="intro-title">Build what matters.</h1>
       <p class="hero-copy">
-        I am Allan Yeung, a builder working across product, data, cloud platforms,
-        and automation. I like practical tools, clear dashboards, reliable workflows,
-        and technology that helps teams make better decisions faster.
+        I'm Allan Yeung. I interview and listen to customers, prioritize what we
+        should build and why, and keep teams focused on the highest-impact work.
+      </p>
+      <p class="hero-copy">
+        I'm especially interested in customer-led products that help developers
+        spend more time building and designing, and less time on operational toil.
       </p>
       <div class="hero-actions" aria-label="Profile links">
         <a class="button primary" href="https://github.com/alyeung">GitHub</a>
@@ -35,59 +38,52 @@
       </div>
     </section>
 
-    <section class="section" id="work" aria-labelledby="work-title">
-      <div class="section-kicker">Focus</div>
-      <h2 id="work-title">Where I spend my energy</h2>
+    <section class="section" id="how" aria-labelledby="how-title">
+      <div class="section-kicker">How I Work</div>
+      <h2 id="how-title">The kind of work I'm drawn to</h2>
       <div class="focus-grid">
         <article>
-          <h3>Product and execution</h3>
-          <p>Translate ambiguous business needs into roadmaps, user stories, demos, and delivery rhythms that keep teams aligned.</p>
+          <h3>Customer-led products</h3>
+          <p>I like starting with real conversations: what customers are trying to do, where they get stuck, and what would make their work meaningfully better.</p>
         </article>
         <article>
-          <h3>Data and decision support</h3>
-          <p>Shape SQL, dashboards, and operating metrics that make performance easier to see and act on.</p>
+          <h3>Developer experience and product fit</h3>
+          <p>At Oracle Cloud, I work on builder tools and developer experiences that help developers spend more time building and designing, and less time on operational toil.</p>
         </article>
         <article>
-          <h3>Cloud and automation</h3>
-          <p>Use APIs, scripting, cloud services, and workflow tools to reduce repetitive work and tighten feedback loops.</p>
+          <h3>Clear tradeoffs, better decisions</h3>
+          <p>I work best with teams that bring a proposal, the tradeoffs behind it, and why they made their recommendation. That creates better prioritization conversations and clearer decisions.</p>
         </article>
       </div>
     </section>
 
-    <section class="section split" id="projects" aria-labelledby="projects-title">
+    <section class="section split" id="life" aria-labelledby="life-title">
       <div>
-        <div class="section-kicker">Selected threads</div>
-        <h2 id="projects-title">A few things I keep coming back to</h2>
+        <div class="section-kicker">Work, Learning, and Life</div>
+        <h2 id="life-title">What I keep practicing</h2>
       </div>
       <div class="project-list">
         <article class="project">
-          <img src="archive/ga-final-project/images/tableau_index.jpg" alt="Data dashboard thumbnail">
-          <h3>Operational dashboards</h3>
-          <p>Turning scattered data sources into useful reporting for product, ecommerce, and operations teams.</p>
+          <img src="archive/ga-final-project/images/tableau_index.jpg" alt="Finance and data thumbnail">
+          <h3>Finance and business judgment</h3>
+          <p>My Berkeley Haas MBA work has focused on finance and real estate, and I serve as Finance Lead for the EWMBA Association.</p>
         </article>
         <article class="project">
-          <img src="archive/ga-final-project/images/postman_index.jpg" alt="API workflow thumbnail">
-          <h3>API-first workflows</h3>
-          <p>Exploring APIs, JSON payloads, and automation patterns that connect services without unnecessary manual steps.</p>
+          <img src="archive/ga-final-project/images/aws_index.jpg" alt="Cloud builder tools thumbnail">
+          <h3>Building for builders</h3>
+          <p>As a product manager for Oracle Cloud builder tools, I focus on experiences that help developers spend more time building and designing, and less time on operational toil.</p>
         </article>
         <article class="project">
-          <img src="archive/ga-final-project/images/aws_index.jpg" alt="Cloud tooling thumbnail">
-          <h3>Cloud learning and tooling</h3>
-          <p>Experimenting with cloud platforms, developer tools, and repeatable ways to learn by building.</p>
+          <img src="archive/ga-final-project/images/fuji_index.jpg" alt="Real estate and living experience thumbnail">
+          <h3>Real estate</h3>
+          <p>I manage a small portfolio of properties that aim to offer a great housing and living experience while operating profitably with healthy margins.</p>
+        </article>
+        <article class="project">
+          <img src="archive/ga-final-project/images/tennis_index.jpg" alt="Tennis and exercise thumbnail">
+          <h3>Family, reading, and exercise</h3>
+          <p>Outside work, I value reading, slow time with family, walks with dogs, and team sports like tennis. Doubles tennis has taught me a lot about trust, adjustment, winning, and losing well.</p>
         </article>
       </div>
-    </section>
-
-    <section class="section archive" aria-labelledby="archive-title">
-      <div>
-        <div class="section-kicker">Archive</div>
-        <h2 id="archive-title">Older work, preserved</h2>
-        <p>
-          This site started as a General Assembly front-end web development project.
-          I am keeping that version available as a snapshot of an earlier chapter.
-        </p>
-      </div>
-      <a class="button secondary" href="archive/ga-final-project/">View archived GA project</a>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- Reposition the homepage around operator, Principal Product Manager, and entrepreneur themes
- Update the hero, navigation, and section copy toward customer-led products, developer experience, finance, real estate, and family/exercise
- Remove the visible archive section from the homepage while keeping archive files available directly

## Verification
- Previewed the root homepage locally
- Checked mobile-width rendering in the in-app browser
- Confirmed root page, stylesheet, and archive/ga-final-project return 200 OK locally
- Confirmed GitHub, LinkedIn, and contact links remain visible